### PR TITLE
Use the current Thread's classLoader for ClientFactories and KeyStrategies

### DIFF
--- a/src/main/java/com/googlecode/hibernate/memcached/MemcachedCacheProvider.java
+++ b/src/main/java/com/googlecode/hibernate/memcached/MemcachedCacheProvider.java
@@ -128,7 +128,7 @@ public class MemcachedCacheProvider implements CacheProvider {
 
     protected KeyStrategy instantiateKeyStrategy(String cls) {
         try {
-            return (KeyStrategy) Class.forName(cls).newInstance();
+            return (KeyStrategy) Thread.currentThread().getContextClassLoader().loadClass(cls).newInstance();
         } catch (InstantiationException e) {
             throw new CacheException("Could not instantiate keyStrategy class", e);
         } catch (IllegalAccessException e) {
@@ -162,7 +162,7 @@ public class MemcachedCacheProvider implements CacheProvider {
 
         Constructor<?> constructor;
         try {
-            constructor = Class.forName(factoryClassName)
+            constructor = Thread.currentThread().getContextClassLoader().loadClass(factoryClassName)
                     .getConstructor(PropertiesHelper.class);
         } catch (ClassNotFoundException e) {
             throw new CacheException(


### PR DESCRIPTION
I have a situation where I want to be able to provide an implementation of the ClientFactory. Class.forName doesn't support this situation well as it won't resolve classes external to this project (such as classes in a Grails project). Simply switching the currentThread's class loader makes this extension point considerably more useful.
